### PR TITLE
Fix indentation in example-docker-compose.yml

### DIFF
--- a/example-docker-compose.yml
+++ b/example-docker-compose.yml
@@ -3,5 +3,5 @@ version: '3'
 services:
   python:
      image: python-docker
-   js:
+  js:
      image: js-docker


### PR DESCRIPTION
Otherwise docker-compose reports:

```
sk@DevOps-with-Docker MINGW64 /c/Code
$ docker-compose.exe -f ./example-docker-compose.yml config
yaml.parser.ParserError: while parsing a block mapping
  in ".\./example-docker-compose.yml", line 4, column 3
expected <block end>, but found '<block mapping start>'
  in ".\./example-docker-compose.yml", line 6, column 4
```